### PR TITLE
fix: silence UnhandledPromiseRejectionWarning in Windows CI

### DIFF
--- a/src/rfc-8252-http-server.ts
+++ b/src/rfc-8252-http-server.ts
@@ -61,6 +61,10 @@ export class RFC8252HTTPServer {
       (resolve, reject) =>
         ([this.oidcParamsResolve, this.oidcParamsReject] = [resolve, reject])
     );
+    // Errors are handled by the caller of this instance.
+    this.oidcParamsPromise.catch(() => {
+      /* Suppress UnhandledPromiseRejectionWarning */
+    });
 
     this.expressApp = express();
     // Identity providers are not strictly required to use the query string to


### PR DESCRIPTION
Not sure why this is only showing up on Windows, but it does and it probably makes sense to fix this.