### PR TITLE
fix: use full OIDC server metadata as cache key MONGOSH-1434

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -158,9 +158,15 @@ export const publicPluginToInternalPluginMap_DoNotUseOutsideOfTests =
  * driver's MongoClientOptions struct.
  *
  * This plugin instance can be passed to multiple MongoClient instances.
- * It caches credentials based on cluster ID and username. If no username is
- * provided when connecting to the MongoDB instance, the cache will be shared
- * across all MongoClients that use this plugin instance.
+ * It caches credentials based on cluster OIDC metadata and username.
+ * Do *not* pass the plugin instance to multiple MongoClient when the
+ * MongoDB deployments they are connecting to do not share a trust relationship
+ * since an untrusted server may be able to advertise malicious OIDC metadata
+ * (this restriction may be lifted in a future version of this library).
+ *
+ * If no username is provided when connecting to the MongoDB instance,
+ * the cache will be shared across all MongoClients that use this
+ * plugin instance.
  *
  * @public
  */

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -10,6 +10,7 @@ import { MongoDBOIDCError } from './types';
 import {
   AbortController,
   errorString,
+  normalizeObject,
   throwIfAborted,
   timeoutSignal,
   withAbortCheck,
@@ -159,7 +160,9 @@ export class MongoDBOIDCPluginImpl implements MongoDBOIDCPlugin {
     principalName ??= null;
 
     const key = JSON.stringify({
-      clientId: serverMetadata.clientId,
+      // If any part of the server metadata changes, we should probably use
+      // a new cache entry.
+      ...normalizeObject(serverMetadata),
       principalName,
     });
     const existing = this.mapUserToAuthState.get(key);

--- a/src/util.ts
+++ b/src/util.ts
@@ -78,3 +78,8 @@ export function withLock<T extends (...args: any[]) => Promise<any>>(
     return result;
   };
 }
+
+// Normalize JS objects by sorting keys so that {a:1,b:2} and {b:2,a:1} are equivalent.
+export function normalizeObject<T extends object>(obj: T): T {
+  return Object.fromEntries(Object.entries(obj).sort()) as T;
+}


### PR DESCRIPTION
We probably want to trigger a full re-authentication when the server metadata does not match the metadata we had used for a previous authentication event.

Also, clarify a note about the current state of this plugin with regards to being able to pass it to multiple MongoClient instances. (This does not affect DevTools as we currently do not have plans to re-use OIDC plugin instances across different MongoDB endpoints at the same time, but may be relevant for other users as well as our future selves.)