### PR TITLE
feat: add support for serializing/deserializing plugin state MONGOSH-1400

### DIFF
--- a/src/log-hook.ts
+++ b/src/log-hook.ts
@@ -239,4 +239,16 @@ export function hookLoggerToMongoLogWriter(
       'Token refresh attempt succeeded'
     );
   });
+
+  emitter.on('mongodb-oidc-plugin:deserialization-failed', (ev) => {
+    log.error(
+      'OIDC-PLUGIN',
+      mongoLogId(1_002_000_020),
+      `${contextPrefix}-oidc`,
+      'State deserialization failed',
+      {
+        ...ev,
+      }
+    );
+  });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,9 @@
 /** @public */
 export interface MongoDBOIDCLogEventsMap {
+  'mongodb-oidc-plugin:deserialization-failed': (event: {
+    error: string;
+  }) => void;
+  'mongodb-oidc-plugin:state-updated': () => void;
   'mongodb-oidc-plugin:local-redirect-accessed': (event: {
     id: string;
   }) => void;


### PR DESCRIPTION
So that we can e.g. store the state in Compass as properties of the connection data and can use a refresh token from a previous session if the IdP allows that.