### PR TITLE
feat: account for most recent driver/spec changes MONGOSH-1440

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8591,7 +8591,7 @@
     },
     "node_modules/mongodb": {
       "version": "5.3.0",
-      "resolved": "git+ssh://git@github.com/addaleax/node-mongodb-native.git#be337ef5b9fd37cf7e3708b8fc2368a3dae19bca",
+      "resolved": "git+ssh://git@github.com/addaleax/node-mongodb-native.git#27f4ad43c91c299c6de43f93935255334b4fd738",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -19501,7 +19501,7 @@
       }
     },
     "mongodb": {
-      "version": "git+ssh://git@github.com/addaleax/node-mongodb-native.git#be337ef5b9fd37cf7e3708b8fc2368a3dae19bca",
+      "version": "git+ssh://git@github.com/addaleax/node-mongodb-native.git#27f4ad43c91c299c6de43f93935255334b4fd738",
       "dev": true,
       "from": "mongodb@github:addaleax/node-mongodb-native#NODE-5191-gitdep",
       "requires": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -144,6 +144,13 @@ export interface MongoDBOIDCPluginOptions {
   throwOnIncompatibleSerializedState?: boolean;
 }
 
+export interface MongoDBOIDCPluginMongoClientOptions {
+  readonly authMechanismProperties: {
+    readonly REQUEST_TOKEN_CALLBACK: OIDCRequestFunction;
+    readonly REFRESH_TOKEN_CALLBACK: OIDCRefreshFunction;
+  };
+}
+
 /** @public */
 export interface MongoDBOIDCPlugin {
   /**
@@ -152,13 +159,10 @@ export interface MongoDBOIDCPlugin {
    *
    * This object should be deep-merged with other, pre-existing
    * MongoClient driver options.
+   *
+   * @public
    */
-  readonly mongoClientOptions: {
-    readonly authMechanismProperties: {
-      readonly REQUEST_TOKEN_CALLBACK: OIDCRequestFunction;
-      readonly REFRESH_TOKEN_CALLBACK: OIDCRefreshFunction;
-    };
-  };
+  readonly mongoClientOptions: MongoDBOIDCPluginMongoClientOptions;
 
   /**
    * The logger instance passed in the options, or a default one otherwise.
@@ -185,15 +189,14 @@ export const publicPluginToInternalPluginMap_DoNotUseOutsideOfTests =
  * driver's MongoClientOptions struct.
  *
  * This plugin instance can be passed to multiple MongoClient instances.
- * It caches credentials based on cluster OIDC metadata and username.
- * Do *not* pass the plugin instance to multiple MongoClient when the
+ * It caches credentials based on cluster OIDC metadata.
+ * Do *not* pass the plugin instance to multiple MongoClient instances when the
  * MongoDB deployments they are connecting to do not share a trust relationship
  * since an untrusted server may be able to advertise malicious OIDC metadata
  * (this restriction may be lifted in a future version of this library).
- *
- * If no username is provided when connecting to the MongoDB instance,
- * the cache will be shared across all MongoClients that use this
- * plugin instance.
+ * Do *not* pass the plugin instnace to multiple MongoClient instances when they
+ * are being used with different usernames (user principals), in the connection
+ * string or in the MongoClient options.
  *
  * @public
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,11 +12,11 @@ export type {
 
 export type {
   TypedEventEmitter,
-  OIDCClientInfo,
+  OIDCCallbackContext,
   OIDCRefreshFunction,
   OIDCRequestFunction,
-  OIDCMechanismServerStep1,
-  OIDCRequestTokenResult,
+  IdPServerInfo,
+  IdPServerResponse,
   OIDCAbortSignal,
   MongoDBOIDCError,
   MongoDBOIDCLogEventsMap,

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,33 +67,34 @@ export interface TypedEventEmitter<EventMap extends object> {
 // esp. in breaking ways.
 
 /**
- * A copy of the Node.js driver's `OIDCMechanismServerStep1`
+ * A copy of the Node.js driver's `IdPServerInfo`
  * @public
  */
-export interface OIDCMechanismServerStep1 {
+export interface IdPServerInfo {
   issuer: string;
   clientId: string;
   requestScopes?: string[];
 }
 
 /**
- * A copy of the Node.js driver's `OIDCRequestTokenResult`
+ * A copy of the Node.js driver's `IdPServerResponse`
  * @public
  */
-export interface OIDCRequestTokenResult {
+export interface IdPServerResponse {
   accessToken: string;
   expiresInSeconds?: number;
   refreshToken?: string;
 }
 
 /**
- * A copy of the Node.js driver's `OIDCClientInfo`
+ * A copy of the Node.js driver's `OIDCCallbackContext`
  * @public
  */
-export interface OIDCClientInfo {
-  principalName?: string;
+export interface OIDCCallbackContext {
+  refreshToken?: string;
   timeoutSeconds?: number;
   timeoutContext?: OIDCAbortSignal;
+  version: number;
 }
 
 /**
@@ -101,19 +102,18 @@ export interface OIDCClientInfo {
  * @public
  */
 export type OIDCRequestFunction = (
-  clientInfo: OIDCClientInfo,
-  serverInfo: OIDCMechanismServerStep1
-) => Promise<OIDCRequestTokenResult>;
+  info: IdPServerInfo,
+  context: OIDCCallbackContext
+) => Promise<IdPServerResponse>;
 
 /**
  * A copy of the Node.js driver's `OIDCRefreshFunction`
  * @public
  */
 export type OIDCRefreshFunction = (
-  clientInfo: OIDCClientInfo,
-  serverInfo: OIDCMechanismServerStep1,
-  tokenResult: OIDCRequestTokenResult
-) => Promise<OIDCRequestTokenResult>;
+  info: IdPServerInfo,
+  context: OIDCCallbackContext
+) => Promise<IdPServerResponse>;
 
 /** @public */
 export type OIDCAbortSignal = {

--- a/test/oidc-test-provider.ts
+++ b/test/oidc-test-provider.ts
@@ -13,7 +13,7 @@ import type {
 } from 'oidc-provider';
 import path from 'path';
 import { once } from 'events';
-import type { OIDCMechanismServerStep1 } from '../src';
+import type { IdPServerInfo } from '../src';
 
 {
   // monkey-patch the test oidc provider so that it returns 'typ: JWT'
@@ -163,7 +163,7 @@ export class OIDCTestProvider {
     await once(this.httpServer, 'close');
   }
 
-  public getMongodbOIDCDBInfo(): OIDCMechanismServerStep1 {
+  public getMongodbOIDCDBInfo(): IdPServerInfo {
     return {
       clientId: oidcClientConfig.client_id,
       issuer: this.issuer,


### PR DESCRIPTION
This moves responsibility for making sure that the plugin instances are being used with a single username and cluster to callers, which should be fine for us in DevTools and which other driver users will likely not care about anyway.