### PR TITLE
chore: run `npm run compile` as part of CI checks

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -37,6 +37,7 @@ functions:
           set -x
 
           . .evergreen/use-node.sh
+          npm run compile
           npm run check
   test:
     - command: shell.exec

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -49,5 +49,7 @@ jobs:
         run: node -e 'process.exitCode = +process.version.startsWith("v14")' || npm install -g npm@8
       - name: Install Dependencies
         run: npm ci --ignore-engines
+      - name: Compile
+        run: npm run compile
       - name: Check
         run: npm run check

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "types": "./index.d.ts",
   "scripts": {
-    "bootstrap": "npm run compile",
     "prepublishOnly": "npm run compile",
     "compile": "tsc -p tsconfig.json && api-extractor run && rimraf 'dist/**/*.d.ts*' && gen-esm-wrapper . ./dist/.esm-wrapper.mjs",
     "typecheck": "tsc -p tsconfig-lint.json --noEmit",

--- a/src/api.ts
+++ b/src/api.ts
@@ -144,6 +144,7 @@ export interface MongoDBOIDCPluginOptions {
   throwOnIncompatibleSerializedState?: boolean;
 }
 
+/** @public */
 export interface MongoDBOIDCPluginMongoClientOptions {
   readonly authMechanismProperties: {
     readonly REQUEST_TOKEN_CALLBACK: OIDCRequestFunction;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export type {
   OpenBrowserReturnType,
   RedirectServerRequestHandler,
   RedirectServerRequestInfo,
+  MongoDBOIDCPluginMongoClientOptions,
 } from './api';
 
 export type {


### PR DESCRIPTION
Otherwise we don’t get failures from `api-extractor` in CI.