### PR TITLE
feat: allow dynamic async/rejectable allowedFlows COMPASS-6811

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -13,6 +13,11 @@ import type {
 
 /** @public */
 export type AuthFlowType = 'auth-code' | 'device-auth';
+/** @public */
+export const ALL_AUTH_FLOW_TYPES: readonly AuthFlowType[] = Object.freeze([
+  'auth-code',
+  'device-auth',
+]);
 
 /**
  * Information that the application needs to show to users when using the
@@ -99,8 +104,20 @@ export interface MongoDBOIDCPluginOptions {
 
   /**
    * Restrict possible OIDC authorization flows to a subset.
+   *
+   * This can either be a static list of supported flows or a function which
+   * returns such a list. In the latter case, the function will be called
+   * for each authentication attempt. The AbortSignal argument can be used
+   * to get insight into when the auth attempt is being aborted, by the
+   * driver or through some other means. (For example, this callback
+   * could be used to inform a user about the fact that re-authentication
+   * is required, and reject if they decline to do so.)
    */
-  allowedFlows?: AuthFlowType[];
+  allowedFlows?:
+    | AuthFlowType[]
+    | ((options: {
+        signal: AbortSignal;
+      }) => Promise<AuthFlowType[]> | AuthFlowType[]);
 
   /**
    * An optional EventEmitter that can be used for recording log events.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { createMongoDBOIDCPlugin } from './api';
+export { createMongoDBOIDCPlugin, ALL_AUTH_FLOW_TYPES } from './api';
 export type {
   MongoDBOIDCPlugin,
   MongoDBOIDCPluginOptions,

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -242,9 +242,9 @@ describe('OIDC plugin (local OIDC provider)', function () {
         expect(timeouts[0].refed).to.equal(false);
         expect(timeouts[0].cleared).to.equal(false);
         // openid-client bases expiration time on the actual current time, so
-        // allow for a small margin of error here.
+        // allow for a small margin of error
         expect(timeouts[0].timeout).to.be.greaterThanOrEqual(9_600_000);
-        expect(timeouts[0].timeout).to.be.greaterThanOrEqual(9_800_000);
+        expect(timeouts[0].timeout).to.be.lessThanOrEqual(9_800_000);
         const refreshStartedEvent = once(
           plugin.logger,
           'mongodb-oidc-plugin:refresh-started'

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -241,7 +241,10 @@ describe('OIDC plugin (local OIDC provider)', function () {
         expect(timeouts).to.have.lengthOf(1);
         expect(timeouts[0].refed).to.equal(false);
         expect(timeouts[0].cleared).to.equal(false);
-        expect(timeouts[0].timeout).to.equal(9_700_000);
+        // openid-client bases expiration time on the actual current time, so
+        // allow for a small margin of error here.
+        expect(timeouts[0].timeout).to.be.greaterThanOrEqual(9_600_000);
+        expect(timeouts[0].timeout).to.be.greaterThanOrEqual(9_800_000);
         const refreshStartedEvent = once(
           plugin.logger,
           'mongodb-oidc-plugin:refresh-started'

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -20,7 +20,7 @@ import {
   oktaBrowserAuthCodeFlow,
   oktaBrowserDeviceAuthFlow,
 } from '../test/oidc-test-provider';
-import { AbortController } from './util';
+import { AbortController, AbortSignal } from './util';
 import { MongoLogWriter } from 'mongodb-log-writer';
 import { PassThrough } from 'stream';
 import { verifySuccessfulAuthCodeFlowLog } from '../test/log-hook-verification-helpers';


### PR DESCRIPTION
This should enable us to display a modal in Compass when re-authentication is required after the initial auth, and prompt the user whether they want to reauthenticate or just return to the connection screen again.