### PR TITLE
feat: do not enable device-auth flow by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ const config = {
   openBrowser: {
     command: 'open -a "Firefox"',
   },
+  // allowedFlows: ['auth-code', 'device-auth'], // if Device Auth Grant flow is required
 };
 
 const client = await MongoClient.connect(

--- a/src/api.ts
+++ b/src/api.ts
@@ -105,6 +105,12 @@ export interface MongoDBOIDCPluginOptions {
   /**
    * Restrict possible OIDC authorization flows to a subset.
    *
+   * The default value is `['auth-code']`, i.e. the Device Authorization Grant
+   * flow is not enabled by default and needs to be enabled explicitly.
+   *
+   * Order of the entries is not relevant. The Authorization Code Flow always
+   * takes precedence over the Device Authorization Grant flow.
+   *
    * This can either be a static list of supported flows or a function which
    * returns such a list. In the latter case, the function will be called
    * for each authentication attempt. The AbortSignal argument can be used

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -677,6 +677,7 @@ describe('OIDC plugin (local OIDC provider)', function () {
           ...defaultOpts,
           openBrowser,
           notifyDeviceFlow,
+          allowedFlows: ['auth-code', 'device-auth'],
         });
       });
 

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -435,6 +435,7 @@ describe('OIDC plugin (local OIDC provider)', function () {
     it('skips auth code flow if browser interactions is disallowed', async function () {
       const plugin = createMongoDBOIDCPlugin({
         ...defaultOpts,
+        allowedFlows: ['auth-code', 'device-auth'],
         openBrowser: false,
         notifyDeviceFlow() {
           throw new Error('device auth');
@@ -467,6 +468,7 @@ describe('OIDC plugin (local OIDC provider)', function () {
     beforeEach(function () {
       plugin = createMongoDBOIDCPlugin({
         ...defaultOpts,
+        allowedFlows: ['auth-code', 'device-auth'],
         redirectURI: 'http://192.0.2.1:1/', // fixed test IP address
         openBrowser: () => Promise.reject(new Error('unreachable')),
         notifyDeviceFlow: functioningDeviceAuthBrowserFlow,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -263,7 +263,7 @@ export class MongoDBOIDCPluginImpl implements MongoDBOIDCPlugin {
     const flowList = new Set<AuthFlowType>(
       typeof this.options.allowedFlows === 'function'
         ? await this.options.allowedFlows({ signal })
-        : this.options.allowedFlows ?? ALL_AUTH_FLOW_TYPES
+        : this.options.allowedFlows ?? ['auth-code']
     );
     // Remove flows from the set whose prerequisites aren't fulfilled.
     if (this.options.openBrowser === false) flowList.delete('auth-code');

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -31,7 +31,6 @@ import type {
   OpenBrowserOptions,
   OpenBrowserReturnType,
 } from './api';
-import { ALL_AUTH_FLOW_TYPES } from './api';
 import { kDefaultOpenBrowserTimeout } from './api';
 import { spawn } from 'child_process';
 


### PR DESCRIPTION
In WRITING-14037, one of the items for driver OIDC callbacks was:

> Recommend considering whether to allow Device Authorization Grant

In mongosh and Compass, we do not want to enable this by default. To make it easier for other Node.js driver users to also use the same defaults as us, let’s flip the default here in the plugin.