### PR TITLE
chore: do slightly stricter URL validation

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -369,7 +369,9 @@ export class MongoDBOIDCPluginImpl implements MongoDBOIDCPlugin {
     // URL has this format.
     new URL(options.url);
     if (!/^[a-zA-Z0-9%/:;_.,=@-]+$/.test(options.url)) {
-      throw new MongoDBOIDCError(`Unexpected format for internally generated URL: '${options.url}'`);
+      throw new MongoDBOIDCError(
+        `Unexpected format for internally generated URL: '${options.url}'`
+      );
     }
     this.logger.emit('mongodb-oidc-plugin:open-browser', {
       customOpener: !!this.options.openBrowser,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -361,8 +361,16 @@ export class MongoDBOIDCPluginImpl implements MongoDBOIDCPlugin {
   private async openBrowser(
     options: OpenBrowserOptions
   ): Promise<OpenBrowserReturnType> {
-    // Consistency check: options.url is a valid URL.
+    // Consistency check: options.url is a valid URL and does not contain
+    // characters that would have special semantics when passed to a
+    // child process spawned with `shell: true`.
+    // That might not be true for the URL we got from the IdP, but since we
+    // wrap it in our own redirect first anyway, we can guarantee that the
+    // URL has this format.
     new URL(options.url);
+    if (!/^[a-zA-Z0-9%/:;_.,=@-]+$/.test(options.url)) {
+      throw new MongoDBOIDCError(`Unexpected format for internally generated URL: '${options.url}'`);
+    }
     this.logger.emit('mongodb-oidc-plugin:open-browser', {
       customOpener: !!this.options.openBrowser,
     });


### PR DESCRIPTION
The URL that is passed to the browser in our plugin is generated by us, so we are in control over the format of it. This commit adds another check that that format is still intact right before we open the browser, so that e.g. a future developer who wants to remove our redirect would not be able to accidentally introduce a security issue by letting URLs pass through which contain characters with special semantics in the shell (e.g. `&` in a query string).