### PR TITLE
chore: add optional .off to TypedEventEmitter

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export interface MongoDBOIDCLogEventsMap {
 export interface TypedEventEmitter<EventMap extends object> {
   // TypeScript uses something like this itself for its EventTarget definitions.
   on<K extends keyof EventMap>(event: K, listener: EventMap[K]): this;
+  off?<K extends keyof EventMap>(event: K, listener: EventMap[K]): this;
   once<K extends keyof EventMap>(event: K, listener: EventMap[K]): this;
   emit<K extends keyof EventMap>(
     event: K,


### PR DESCRIPTION
We don’t make use of this in the plugin’s own code, but it can be convenient for downstream users to know that this method may be there (e.g. when accessing a plugin’s `.logger` property).