### PR TITLE
feat: add public interface for userinfo, introspect, and revoke methods COMPASS-7094

### DIFF
--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -1058,7 +1058,9 @@ describe('OIDC plugin (local OIDC provider)', function () {
           await plugin.userInfo({} as any, { signal: controller.signal });
           expect.fail('Expected userInfo to throw');
         } catch (err) {
-          expect(err).to.have.property('message', 'This operation was aborted');
+          expect(err)
+            .to.have.property('message')
+            .match(/aborted/i);
         }
       });
     });
@@ -1078,7 +1080,9 @@ describe('OIDC plugin (local OIDC provider)', function () {
           });
           expect.fail('Expected introspect to throw');
         } catch (err) {
-          expect(err).to.have.property('message', 'This operation was aborted');
+          expect(err)
+            .to.have.property('message')
+            .match(/aborted/i);
         }
       });
     });
@@ -1098,7 +1102,9 @@ describe('OIDC plugin (local OIDC provider)', function () {
           });
           expect.fail('Expected revoke to throw');
         } catch (err) {
-          expect(err).to.have.property('message', 'This operation was aborted');
+          expect(err)
+            .to.have.property('message')
+            .match(/aborted/i);
         }
       });
     });


### PR DESCRIPTION
This patch adds public interfaces for oidc / oauth spec methods for getting user info, introspecting, and revoking the tokens. For the tests, I tried using `OidcTestProvider`, but the tokens returned from it were immediately expired and I couldn't figure out why, I opted for just stubbing the client instead.