### PR TITLE
feat: improve diagnostics, allow custom HTTP options, account for IdP support for scopes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@mongodb-js/eslint-config-devtools": "^0.9.9",
         "@mongodb-js/mocha-config-devtools": "^1.0.0",
         "@mongodb-js/monorepo-tools": "^1.1.4",
-        "@mongodb-js/oidc-mock-provider": "^0.7.1",
+        "@mongodb-js/oidc-mock-provider": "^0.8.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-devtools": "^1.0.0",
         "@types/chai": "^4.2.21",
@@ -2854,9 +2854,9 @@
       "dev": true
     },
     "node_modules/@mongodb-js/oidc-mock-provider": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-mock-provider/-/oidc-mock-provider-0.7.1.tgz",
-      "integrity": "sha512-l2yYBoAqDV6Qoqenc7PUOIeEtgr3LDu2t1dvEJ2+mdncIlHpNT0oKSbwR7vjSuRSYk3AZgoj0VOPrw8dJ4XxDQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-mock-provider/-/oidc-mock-provider-0.8.0.tgz",
+      "integrity": "sha512-5CrrdD07AmsRVHmq5bGPmJabGa5YWX/B1GJNlI/oXiYQzmBdPQ0XklpjPGnCEEgkcG7OsEgrRjcDnuofBkdNPg==",
       "dev": true,
       "dependencies": {
         "yargs": "17.7.2"
@@ -18546,9 +18546,9 @@
       }
     },
     "@mongodb-js/oidc-mock-provider": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-mock-provider/-/oidc-mock-provider-0.7.1.tgz",
-      "integrity": "sha512-l2yYBoAqDV6Qoqenc7PUOIeEtgr3LDu2t1dvEJ2+mdncIlHpNT0oKSbwR7vjSuRSYk3AZgoj0VOPrw8dJ4XxDQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-mock-provider/-/oidc-mock-provider-0.8.0.tgz",
+      "integrity": "sha512-5CrrdD07AmsRVHmq5bGPmJabGa5YWX/B1GJNlI/oXiYQzmBdPQ0XklpjPGnCEEgkcG7OsEgrRjcDnuofBkdNPg==",
       "dev": true,
       "requires": {
         "yargs": "17.7.2"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@mongodb-js/eslint-config-devtools": "^0.9.9",
     "@mongodb-js/mocha-config-devtools": "^1.0.0",
     "@mongodb-js/monorepo-tools": "^1.1.4",
-    "@mongodb-js/oidc-mock-provider": "^0.7.1",
+    "@mongodb-js/oidc-mock-provider": "^0.8.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-devtools": "^1.0.0",
     "@types/chai": "^4.2.21",

--- a/src/api.ts
+++ b/src/api.ts
@@ -10,6 +10,24 @@ import type {
   OIDCRequestFunction,
   TypedEventEmitter,
 } from './types';
+import type { RequestOptions } from 'https';
+
+/** @public */
+export type HttpOptions = Partial<
+  Pick<
+    RequestOptions,
+    | 'agent'
+    | 'ca'
+    | 'cert'
+    | 'crl'
+    | 'headers'
+    | 'key'
+    | 'lookup'
+    | 'passphrase'
+    | 'pfx'
+    | 'timeout'
+  >
+>;
 
 /** @public */
 export type AuthFlowType = 'auth-code' | 'device-auth';
@@ -167,6 +185,13 @@ export interface MongoDBOIDCPluginOptions {
    * message being emitted but otherwise be ignored.
    */
   throwOnIncompatibleSerializedState?: boolean;
+
+  /**
+   * Provide custom HTTP options for individual HTTP calls.
+   */
+  customHttpOptions?:
+    | HttpOptions
+    | ((url: string, options: Readonly<HttpOptions>) => HttpOptions);
 }
 
 /** @public */

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export type {
   RedirectServerRequestHandler,
   RedirectServerRequestInfo,
   MongoDBOIDCPluginMongoClientOptions,
+  HttpOptions,
 } from './api';
 
 export type {

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -308,6 +308,7 @@ describe('OIDC plugin (local OIDC provider)', function () {
         expect(serializedData.oidcPluginStateVersion).to.equal(0);
         expect(serializedData.state).to.have.lengthOf(1);
         expect(serializedData.state[0][0]).to.be.a('string');
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         expect(Object.keys(serializedData.state[0][1]).sort()).to.deep.equal([
           'currentTokenSet',
           'lastIdTokenClaims',

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -827,6 +827,20 @@ describe('OIDC plugin (local OIDC provider)', function () {
       }
     });
 
+    it('includes a helpful error message when attempting to reach out to invalid issuer', async function () {
+      try {
+        await requestToken(plugin, {
+          clientId: 'clientId',
+          issuer: 'https://doesnotexist.mongodb.com/',
+        });
+        expect.fail('missed exception');
+      } catch (err: any) {
+        expect(err.message).to.include(
+          'Unable to fetch issuer metadata for "https://doesnotexist.mongodb.com/":'
+        );
+      }
+    });
+
     context('with an issuer that reports custom metadata', function () {
       let server: HTTPServer;
       let response: Record<string, unknown>;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -775,6 +775,7 @@ export class MongoDBOIDCPluginImpl implements MongoDBOIDCPlugin {
     }
 
     this.logger.emit('mongodb-oidc-plugin:auth-succeeded', {
+      tokenType: state.currentTokenSet.set.token_type ?? null, // DPoP or Bearer
       hasRefreshToken: !!state.currentTokenSet.set.refresh_token,
       expiresAt: state.currentTokenSet.set.expires_at
         ? new Date(state.currentTokenSet.set.expires_at * 1000).toISOString()

--- a/src/rfc-8252-http-server.ts
+++ b/src/rfc-8252-http-server.ts
@@ -76,6 +76,15 @@ export class RFC8252HTTPServer {
     this.expressApp.use(express.urlencoded({ extended: false }));
     this.expressApp.use(express.json());
     this.expressApp.use((req, res, next) => {
+      let url = req.url;
+      if (this.listeningRedirectUrl) {
+        try {
+          url = new URL(req.url, this.listeningRedirectUrl).toString();
+        } catch {
+          // should never really get to this point, but this is only for debugging
+        }
+      }
+      this.logger.emit('mongodb-oidc-plugin:inbound-http-request', { url });
       // Set some default HTTP security headers. The CSP here is fairly strict,
       // but specific handlers can override these as necessary.
       res.setHeader('Content-Security-Policy', "default-src 'self'");

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,8 @@ export interface MongoDBOIDCLogEventsMap {
   }) => void;
   'mongodb-oidc-plugin:destroyed': () => void;
   'mongodb-oidc-plugin:missing-id-token': () => void;
+  'mongodb-oidc-plugin:outbound-http-request': (event: { url: string }) => void;
+  'mongodb-oidc-plugin:inbound-http-request': (event: { url: string }) => void;
 }
 
 /** @public */

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,8 +139,9 @@ export class MongoDBOIDCError extends Error {
   /** @internal */
   private [MongoDBOIDCErrorTag] = true;
 
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, { cause }: { cause?: unknown } = {}) {
+    // @ts-expect-error `cause` is not supported in Node.js 14
+    super(message, { cause });
   }
 
   static isMongoDBOIDCError(value: unknown): value is MongoDBOIDCError {

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export interface MongoDBOIDCLogEventsMap {
   'mongodb-oidc-plugin:skip-auth-attempt': (event: { reason: string }) => void;
   'mongodb-oidc-plugin:auth-failed': (event: { error: string }) => void;
   'mongodb-oidc-plugin:auth-succeeded': (event: {
+    tokenType: string | null;
     hasRefreshToken: boolean;
     expiresAt: string | null;
   }) => void;

--- a/src/util.ts
+++ b/src/util.ts
@@ -118,3 +118,14 @@ export function validateSecureHTTPUrl(
     throw err;
   }
 }
+
+export function messageFromError(err: unknown): string {
+  return String(
+    err &&
+      typeof err === 'object' &&
+      'message' in err &&
+      typeof err.message === 'string'
+      ? err.message
+      : err
+  );
+}


### PR DESCRIPTION
The commits here are fairly independent (and can be reviewed indepedently), but they would otherwise be fairly small changes or conflict with each other, so this is just one big PR to handle all of them together. If it's easier, I'm happy to split them out and PR them sequentially as well 🙂 

##### chore: add token type to auth-succeeded log event


##### fix: improve error message when `Issuer.discover()` fails COMPASS-7605


##### chore: disable last remaining eslint warning in tests


##### feat: do not request scopes if the IdP announces lack of support COMPASS-7437


##### feat: track HTTP calls, allow custom HTTP options MONGOSH-1712

(This would be used to implement `useSystemCA` support in devtools-connect)