### PR TITLE
feat: improve logging and testing, allow using id tokens instead of access tokens

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -191,6 +191,12 @@ export interface MongoDBOIDCPluginOptions {
   customHttpOptions?:
     | HttpOptions
     | ((url: string, options: Readonly<HttpOptions>) => HttpOptions);
+
+  /**
+   * Pass ID tokens in place of access tokens. For debugging/working around
+   * broken identity providers.
+   */
+  passIdTokenAsAccessToken?: boolean;
 }
 
 /** @public */

--- a/src/log-hook.ts
+++ b/src/log-hook.ts
@@ -229,7 +229,7 @@ export function hookLoggerToMongoLogWriter(
 
   emitter.on(
     'mongodb-oidc-plugin:auth-succeeded',
-    ({ tokenType, refreshToken, expiresAt }) => {
+    ({ tokenType, refreshToken, expiresAt, passIdTokenAsAccessToken }) => {
       log.info(
         'OIDC-PLUGIN',
         mongoLogId(1_002_000_017),
@@ -239,6 +239,7 @@ export function hookLoggerToMongoLogWriter(
           tokenType,
           refreshToken,
           expiresAt,
+          passIdTokenAsAccessToken,
         }
       );
     }

--- a/src/log-hook.ts
+++ b/src/log-hook.ts
@@ -140,6 +140,15 @@ export function hookLoggerToMongoLogWriter(
     );
   });
 
+  emitter.on('mongodb-oidc-plugin:open-browser-complete', () => {
+    log.info(
+      'OIDC-PLUGIN',
+      mongoLogId(1_002_000_025),
+      `${contextPrefix}-oidc`,
+      'Successfully opened browser'
+    );
+  });
+
   emitter.on('mongodb-oidc-plugin:notify-device-flow', () => {
     log.info(
       'OIDC-PLUGIN',
@@ -218,33 +227,50 @@ export function hookLoggerToMongoLogWriter(
     );
   });
 
-  emitter.on('mongodb-oidc-plugin:auth-succeeded', (ev) => {
+  emitter.on(
+    'mongodb-oidc-plugin:auth-succeeded',
+    ({ tokenType, refreshToken, expiresAt }) => {
+      log.info(
+        'OIDC-PLUGIN',
+        mongoLogId(1_002_000_017),
+        `${contextPrefix}-oidc`,
+        'Authentication succeeded',
+        {
+          tokenType,
+          refreshToken,
+          expiresAt,
+        }
+      );
+    }
+  );
+
+  emitter.on('mongodb-oidc-plugin:refresh-skipped', (ev) => {
     log.info(
       'OIDC-PLUGIN',
-      mongoLogId(1_002_000_017),
+      mongoLogId(1_002_000_026),
       `${contextPrefix}-oidc`,
-      'Authentication succeeded',
-      {
-        ...ev,
-      }
+      'Token refresh attempt skipped',
+      { ...ev }
     );
   });
 
-  emitter.on('mongodb-oidc-plugin:refresh-started', () => {
+  emitter.on('mongodb-oidc-plugin:refresh-started', (ev) => {
     log.info(
       'OIDC-PLUGIN',
       mongoLogId(1_002_000_018),
       `${contextPrefix}-oidc`,
-      'Token refresh attempt started'
+      'Token refresh attempt started',
+      { ...ev }
     );
   });
 
-  emitter.on('mongodb-oidc-plugin:refresh-succeeded', () => {
+  emitter.on('mongodb-oidc-plugin:refresh-succeeded', (ev) => {
     log.info(
       'OIDC-PLUGIN',
       mongoLogId(1_002_000_019),
       `${contextPrefix}-oidc`,
-      'Token refresh attempt succeeded'
+      'Token refresh attempt succeeded',
+      { ...ev }
     );
   });
 
@@ -295,6 +321,16 @@ export function hookLoggerToMongoLogWriter(
       `${contextPrefix}-oidc`,
       'Inbound HTTP request',
       { url: redactUrl(ev.url) }
+    );
+  });
+
+  emitter.on('mongodb-oidc-plugin:state-updated', (ev) => {
+    log.info(
+      'OIDC-PLUGIN',
+      mongoLogId(1_002_000_027),
+      `${contextPrefix}-oidc`,
+      'Updated internal token store state',
+      { ...ev }
     );
   });
 }

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -168,6 +168,27 @@ describe('OIDC plugin (local OIDC provider)', function () {
       ]);
     });
 
+    it('can optionally use id tokens instead of access tokens', async function () {
+      pluginOptions = {
+        ...defaultOpts,
+        allowedFlows: ['auth-code'],
+        openBrowser: functioningAuthCodeBrowserFlow,
+        passIdTokenAsAccessToken: true,
+      };
+      plugin = createMongoDBOIDCPlugin(pluginOptions);
+      const result = await requestToken(
+        plugin,
+        provider.getMongodbOIDCDBInfo()
+      );
+      const accessTokenContents = getJWTContents(result.accessToken);
+      expect(accessTokenContents.sub).to.equal('testuser');
+      expect(accessTokenContents.aud).to.equal(
+        provider.getMongodbOIDCDBInfo().clientId
+      );
+      expect(accessTokenContents.client_id).to.equal(undefined);
+      verifySuccessfulAuthCodeFlowLog(await readLog());
+    });
+
     it('will refresh tokens if they are expiring', async function () {
       const skipAuthAttemptEvent = once(
         logger,

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -266,18 +266,22 @@ describe('OIDC plugin (local OIDC provider)', function () {
           provider.getMongodbOIDCDBInfo()
         );
 
-        expect(timeouts).to.have.lengthOf(1);
+        expect(timeouts).to.have.lengthOf(2);
+        // 0 -> browser timeout, 1 -> refresh timeout
         expect(timeouts[0].refed).to.equal(false);
         expect(timeouts[0].cleared).to.equal(false);
+        expect(timeouts[0].timeout).to.equal(60_000);
+        expect(timeouts[1].refed).to.equal(false);
+        expect(timeouts[1].cleared).to.equal(false);
         // openid-client bases expiration time on the actual current time, so
         // allow for a small margin of error
-        expect(timeouts[0].timeout).to.be.greaterThanOrEqual(9_600_000);
-        expect(timeouts[0].timeout).to.be.lessThanOrEqual(9_800_000);
+        expect(timeouts[1].timeout).to.be.greaterThanOrEqual(9_600_000);
+        expect(timeouts[1].timeout).to.be.lessThanOrEqual(9_800_000);
         const refreshStartedEvent = once(
           plugin.logger,
           'mongodb-oidc-plugin:refresh-started'
         );
-        timeouts[0].fn();
+        timeouts[1].fn();
         await refreshStartedEvent;
         await once(plugin.logger, 'mongodb-oidc-plugin:refresh-succeeded');
 
@@ -302,14 +306,14 @@ describe('OIDC plugin (local OIDC provider)', function () {
         provider.accessTokenTTLSeconds = 10000;
         await requestToken(plugin, provider.getMongodbOIDCDBInfo());
 
-        expect(timeouts).to.have.lengthOf(1);
-        expect(timeouts[0].refed).to.equal(false);
-        expect(timeouts[0].cleared).to.equal(false);
+        expect(timeouts).to.have.lengthOf(2);
+        expect(timeouts[1].refed).to.equal(false);
+        expect(timeouts[1].cleared).to.equal(false);
         await plugin.destroy();
 
-        expect(timeouts).to.have.lengthOf(1);
-        expect(timeouts[0].refed).to.equal(false);
-        expect(timeouts[0].cleared).to.equal(true);
+        expect(timeouts).to.have.lengthOf(2);
+        expect(timeouts[1].refed).to.equal(false);
+        expect(timeouts[1].cleared).to.equal(true);
       });
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,10 @@ export interface MongoDBOIDCLogEventsMap {
   'mongodb-oidc-plugin:deserialization-failed': (event: {
     error: string;
   }) => void;
-  'mongodb-oidc-plugin:state-updated': () => void;
+  'mongodb-oidc-plugin:state-updated': (event: {
+    updateId: number;
+    timerDuration: number | undefined;
+  }) => void;
   'mongodb-oidc-plugin:local-redirect-accessed': (event: {
     id: string;
   }) => void;
@@ -32,19 +35,40 @@ export interface MongoDBOIDCLogEventsMap {
   'mongodb-oidc-plugin:open-browser': (event: {
     customOpener: boolean;
   }) => void;
+  'mongodb-oidc-plugin:open-browser-complete': () => void;
   'mongodb-oidc-plugin:notify-device-flow': () => void;
   'mongodb-oidc-plugin:auth-attempt-started': (event: { flow: string }) => void;
   'mongodb-oidc-plugin:auth-attempt-succeeded': () => void;
   'mongodb-oidc-plugin:auth-attempt-failed': (event: { error: string }) => void;
-  'mongodb-oidc-plugin:refresh-started': () => void;
-  'mongodb-oidc-plugin:refresh-succeeded': () => void;
-  'mongodb-oidc-plugin:refresh-failed': (event: { error: string }) => void;
+  'mongodb-oidc-plugin:refresh-skipped': (event: {
+    triggeringUpdateId: number;
+    expectedRefreshToken: string | null;
+    actualRefreshToken: string | null;
+  }) => void;
+  'mongodb-oidc-plugin:refresh-started': (event: {
+    triggeringUpdateId: number;
+    refreshToken: string | null;
+  }) => void;
+  'mongodb-oidc-plugin:refresh-succeeded': (event: {
+    triggeringUpdateId: number;
+    refreshToken: string | null;
+  }) => void;
+  'mongodb-oidc-plugin:refresh-failed': (event: {
+    error: string;
+    triggeringUpdateId: number;
+    refreshToken: string | null;
+  }) => void;
   'mongodb-oidc-plugin:skip-auth-attempt': (event: { reason: string }) => void;
   'mongodb-oidc-plugin:auth-failed': (event: { error: string }) => void;
   'mongodb-oidc-plugin:auth-succeeded': (event: {
     tokenType: string | null;
-    hasRefreshToken: boolean;
+    refreshToken: string | null;
     expiresAt: string | null;
+    tokens: {
+      accessToken: string | undefined;
+      idToken: string | undefined;
+      refreshToken: string | undefined;
+    };
   }) => void;
   'mongodb-oidc-plugin:destroyed': () => void;
   'mongodb-oidc-plugin:missing-id-token': () => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,7 @@ export interface MongoDBOIDCLogEventsMap {
     tokenType: string | null;
     refreshToken: string | null;
     expiresAt: string | null;
+    passIdTokenAsAccessToken: boolean;
     tokens: {
       accessToken: string | undefined;
       idToken: string | undefined;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 import type { OIDCAbortSignal } from './types';
+import { createHash, randomBytes } from 'crypto';
 
 class AbortError extends Error {
   constructor() {
@@ -120,5 +121,17 @@ export function messageFromError(err: unknown): string {
       typeof err.message === 'string'
       ? err.message
       : err
+  );
+}
+
+const salt = randomBytes(16);
+export function getRefreshTokenId(
+  token: string | null | undefined
+): string | null {
+  if (!token) return null;
+  // Add a prefix to indicate that this isn't an actual refresh token,
+  // that might unnecessarily worry users
+  return (
+    'debugid:' + createHash('sha256').update(salt).update(token).digest('hex')
   );
 }

--- a/test/log-hook-verification-helpers.ts
+++ b/test/log-hook-verification-helpers.ts
@@ -101,7 +101,7 @@ export function verifySuccessfulAuthCodeFlowLog(entries: any[]): void {
       ctx: 'test-oidc',
       msg: 'Authentication succeeded',
       attr: (attr: Record<string, unknown>) => {
-        expect(attr.hasRefreshToken).to.equal(true);
+        expect(attr.refreshToken).to.be.a('string');
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         expect(new Date(attr.expiresAt as string).toISOString()).to.equal(
           attr.expiresAt


### PR DESCRIPTION
#### feat: improve logging and testing

Miscellaneous improvements around logging inside the plugin, plus a few preparations
for downstream diagnostics improvements:
- Emit an event when the browser has successfully been opened (COMPASS-8121)
- Improve logging around token refreshing (MONGOSH-1795)
- Emit acquired tokens in an event (MONGOSH-1845)
- Use `.timers` for also testing the browser timer

##### feat: allow using id tokens instead of access tokens MONGOSH-1843

