### PR TITLE
fix: include username in server metadata key

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,9 @@ export interface MongoDBOIDCLogEventsMap {
   'mongodb-oidc-plugin:missing-id-token': () => void;
   'mongodb-oidc-plugin:outbound-http-request': (event: { url: string }) => void;
   'mongodb-oidc-plugin:inbound-http-request': (event: { url: string }) => void;
+  'mongodb-oidc-plugin:received-server-params': (event: {
+    params: OIDCCallbackParams;
+  }) => void;
 }
 
 /** @public */


### PR DESCRIPTION
This is something we should have ideally always been doing (as hinted at by the doc comment for `getAuthState()`), but which the driver only added back support for in 6.7.0.

This shouldn't have an immediate impact on our products, because we already have some mitigations in place for the fact that usernames were previously not being taken into account (e.g. here:
https://github.com/mongodb-js/mongosh/blob/adc530e7ffcf092677d944fd69670c5cbd8e103d/packages/service-provider-server/src/cli-service-provider.ts#L172 ), but is semantically the right thing to do and should give us a bit more flexibility in the future.

Also, add a test that confirms that changes to server metadata/username actually have the expected effect, and emit a message bus event that shares information about the server metadata, as that may be helpful debugging information.