### PR TITLE
chore: create a release workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -52,7 +52,7 @@ jobs:
   package:
     name: Package for publishing
     runs-on: ubuntu-latest
-    if: ${{ contains(github.head_ref, 'release') }}
+    if: ${{ startsWith(github.head_ref, 'release/') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -48,3 +48,30 @@ jobs:
         run: npm run compile
       - name: Check
         run: npm run check
+
+  package:
+    name: Package for publishing
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.head_ref, 'release') }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Install Dependencies
+        run: npm ci --ignore-engines
+
+      - name: Compile
+        run: npm run compile
+
+      - name: Pack
+        run: npm pack
+
+      - name: Archive artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: package
+          path: mongodb-js-oidc-plugin-*.tgz

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,37 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_update_type:
+        description: What type of version bump should be done
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Bump version
+        run: |
+          echo "new-version=$(npm version ${{ github.event.inputs.version_update_type }} --no-git-tag-version)" >> $GITHUB_OUTPUT
+        id: version
+
+      - name: Create Release PR
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # 7.0.5
+        with:
+          branch: release/${{ steps.version.outputs.new-version }}
+          title: Prepare for ${{ steps.version.outputs.new-version }}
+          draft: false
+          body: An automated PR for next release.
+          commit-message: Prepare for ${{ steps.version.outputs.new-version }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,56 @@
+name: Publish Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    environment: Production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Install Dependencies
+        run: npm ci --ignore-engines
+
+      - name: Compile
+        run: npm run compile
+
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Read Version
+        id: get-version
+        run: |
+          echo "package_version=$(cat package.json | jq '.version' | tr -d '"')" >> $GITHUB_OUTPUT
+
+      - name: Find Release PR
+        id: find-pull-request
+        uses: juliangruber/find-pull-request-action@48b6133aa6c826f267ebd33aa2d29470f9d9e7d0 # 1.9.0
+        with:
+          branch: ${{ github.ref }}
+
+      - name: Merge Pull Request
+        uses: juliangruber/merge-pull-request-action@9234b8714dda9a08f3d1df5b2a6a3abd7b695353 # 1.3.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ steps.find-pull-request.outputs.number }}
+          method: squash
+
+      - name: Publish Github Release
+        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # 1.14.0
+        with:
+          generateReleaseNotes: true
+          name: ${{ steps.get-version.outputs.package_version }}
+          commit: main
+          tag: ${{ steps.get-version.outputs.package_version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: false

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Read Version
         id: get-version
         run: |
-          echo "package_version=$(cat package.json | jq '.version' | tr -d '"')" >> $GITHUB_OUTPUT
+          echo "package_version=$(cat package.json | jq -r '.version')" >> $GITHUB_OUTPUT
 
       - name: Find Release PR
         id: find-pull-request


### PR DESCRIPTION
This PR adds the following:
1. A "Prepare Release" workflow that can be invoked with an update type (patch/minor/major). Once run, it will bump the package version, create a `release/version` branch, and open a PR.
2. A `package` job for the PR workflow. This is run only on `release/*` branches and will run `npm pack` and archive the output.
3. A "Publish Release" workflow that needs to be manually invoked. It will run `npm publish`, merge the release PR, then create a github release with an autogenerated changelog. This workflow needs to access the npm token as an environment secret and as such needs an approval from a member of the devtools team to run (who is not the person who ran the workflow).

I'm working with IT on getting the actual token, so this wouldn't work until we get it.