### PR TITLE
chore(ci): tweak release workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking
+    - title: Features
+      labels:
+        - feature
+    - title: Fixes
+      labels:
+        - fix
+    - title: Other Changes
+      labels:
+        - '*'

--- a/.github/workflows/assign-labels.yml
+++ b/.github/workflows/assign-labels.yml
@@ -1,0 +1,10 @@
+on:
+  pull_request_target:
+    types: [opened, edited]
+
+name: conventional-release-labels
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bcoe/conventional-release-labels@886f696738527c7be444262c327c89436dfb95a8 # 1.3.1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # 7.0.5
         with:
           branch: release/${{ steps.version.outputs.new-version }}
-          title: 'chore: Bump version to ${{ steps.version.outputs.new-version }}'
+          title: 'chore: bump version to ${{ steps.version.outputs.new-version }}'
           draft: false
           body: An automated PR for next release.
           commit-message: Bump package.json version to ${{ steps.version.outputs.new-version }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -31,7 +31,8 @@ jobs:
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # 7.0.5
         with:
           branch: release/${{ steps.version.outputs.new-version }}
-          title: Prepare for ${{ steps.version.outputs.new-version }}
+          title: 'chore: Bump version to ${{ steps.version.outputs.new-version }}'
           draft: false
           body: An automated PR for next release.
-          commit-message: Prepare for ${{ steps.version.outputs.new-version }}
+          commit-message: Bump package.json version to ${{ steps.version.outputs.new-version }}
+          labels: ignore-for-release

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,7 +7,9 @@ jobs:
   publish:
     name: Publish Release
     runs-on: ubuntu-latest
-    environment: Production
+    environment:
+      name: Production
+      url: https://www.npmjs.com/package/@mongodb-js/oidc-plugin/v/${{ steps.get-version.outputs.package_version }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
After the first release, this is a follow-up PR that smooths some of the rough edges:
1. Update the `publish-release` workflow to include the url of the package we've uploaded.
2. Update the `prepare-release` to create a PR with a title that conforms to the conventional commit conventions as well as add a label to ignore the PR from the changelog.
3. Add a `release.yml` config to categorize the changelog based on labels.
4. Add a `assign-labels` workflow to assign labels based on PR title. Those labels are later used by the changelog generator.