### PR TITLE
chore: add better releasing docs

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           branch: release/${{ steps.version.outputs.new-version }}
           title: 'chore: bump version to ${{ steps.version.outputs.new-version }}'
+          token: ${{ secrets.SVC_DEVTOOLSBOT_TOKEN }}
           draft: false
           body: |
             An automated PR for next release.

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -4,12 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       version_update_type:
-        description: What type of version bump should be done
+        description: What type of version bump should be done.
         type: choice
         options:
           - patch
           - minor
           - major
+      exact_version:
+        description: An optional exact version to bump to. If this is specified, version_update_type will be ignored.
+        type: string
+        required: false
 
 jobs:
   prepare:
@@ -24,7 +28,7 @@ jobs:
 
       - name: Bump version
         run: |
-          echo "new-version=$(npm version ${{ github.event.inputs.version_update_type }} --no-git-tag-version)" >> $GITHUB_OUTPUT
+          echo "new-version=$(npm version ${{ github.event.inputs.exact_version || github.event.inputs.version_update_type }} --no-git-tag-version)" >> $GITHUB_OUTPUT
         id: version
 
       - name: Create Release PR
@@ -33,6 +37,11 @@ jobs:
           branch: release/${{ steps.version.outputs.new-version }}
           title: 'chore: bump version to ${{ steps.version.outputs.new-version }}'
           draft: false
-          body: An automated PR for next release.
+          body: |
+            An automated PR for next release.
+
+            **Note**: Don't merge this manually. Instead, run the [Publish Release](${{ github.server_url }}/${{github.repository}}/actions/workflows/publish-release.yml) workflow using `release/${{ steps.version.outputs.new-version }}` as target branch.
+
+            This PR will be merged automatically and a new Github release will be tagged when the package is published to NPM.
           commit-message: 'chore: bump version to ${{ steps.version.outputs.new-version }}'
           labels: ignore-for-release

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Merge Pull Request
         uses: juliangruber/merge-pull-request-action@9234b8714dda9a08f3d1df5b2a6a3abd7b695353 # 1.3.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.SVC_DEVTOOLSBOT_TOKEN }}
           number: ${{ steps.find-pull-request.outputs.number }}
           method: squash
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+## Workflow
+
+MongoDB welcomes community contributions! If you’re interested in making a contribution to the MongoDB Shell, please follow the steps below before you start writing any code:
+
+1. Sign the [contributor's agreement](https://www.mongodb.com/contributor). This will allow us to review and accept contributions.
+1. Fork the repository on GitHub
+1. Create a branch with a name that briefly describes your feature
+1. Implement your feature or bug fix
+1. Add new test cases that verify your bug fix or make sure no one
+   unintentionally breaks your feature in the future and run them with `npm test`
+   - You can use `it.only()` instead of `it()` in mocha tests to run only a subset of tests.
+     This can be helpful, because running the full test suite likely takes some time.
+1. Add comments around your new code that explain what's happening
+1. Commit and push your changes to your branch then submit a pull request
+
+## Bugs
+
+You can report new bugs by
+[creating a new issue](https://github.com/mongodb-js/oidc-plugin/issues).
+Please include as much information as possible about your environment.
+
+## Releasing
+
+To release a new version of this plugin, follow these steps:
+
+1. Run the [Prepare Release](https://github.com/mongodb-js/oidc-plugin/actions/workflows/prepare-release.yml) workflow with the desired type of version bump (major, minor, patch) or an exact version.
+1. The workflow will create a new release branch and a new pull request with the changes. Review the changes and ensure everything on CI looks good.
+1. Run the [Publish Release](https://github.com/mongodb-js/oidc-plugin/actions/workflows/publish-release.yml) workflow from the release branch. This will publish the plugin to npm, merge the release PR, and create a new github release.


### PR DESCRIPTION
This PR adds a `Contributing.md` that has a releasing section and updates the PR description of the prepare-release workflow with instructions for how to finish the release.

Additionally, it replaces the token used to creating and merging the release PR with the token we have for devtoolsbot. This should result in normal workflows getting run both on the release PR and the main branch after merging.