### PR TITLE
fix: filter out duplicate dns results MONGOSH-2027

### DIFF
--- a/src/rfc-8252-http-server.spec.ts
+++ b/src/rfc-8252-http-server.spec.ts
@@ -1,4 +1,4 @@
-import { RFC8252HTTPServer } from './rfc-8252-http-server';
+import { getAllInterfaces, RFC8252HTTPServer } from './rfc-8252-http-server';
 import { expect } from 'chai';
 import type { Server as HTTPServer } from 'http';
 import { createServer as createHTTPServer } from 'http';
@@ -487,19 +487,13 @@ describe('RFC8252HTTPServer', function () {
     });
   });
 
-  context('with dns duplicates', function () {
+  context('getAllInterfaces', function () {
     let dnsLookupStub: sinon.SinonStub;
-    const _getAllInterfaces = RFC8252HTTPServer['_getAllInterfaces'];
-
     this.beforeEach(function () {
-      dnsLookupStub = sinon.stub(dns, 'lookup');
+      dnsLookupStub = sinon.stub();
     });
 
-    this.afterEach(function () {
-      sinon.restore();
-    });
-
-    it('only filters exact duplicates', async function () {
+    it('filters out exact duplicates', async function () {
       dnsLookupStub.resolves([
         { address: '127.0.0.1', family: 4 },
         { address: '127.0.0.1', family: 4 },
@@ -507,7 +501,7 @@ describe('RFC8252HTTPServer', function () {
         { address: '[::1]', family: 6 },
       ]);
 
-      const interfaces = await _getAllInterfaces('localhost');
+      const interfaces = await getAllInterfaces('localhost', dnsLookupStub);
 
       expect(interfaces).to.have.lengthOf(2);
       expect(interfaces[0].address).to.equal('127.0.0.1');
@@ -522,7 +516,7 @@ describe('RFC8252HTTPServer', function () {
         { address: '127.0.0.1', family: 6 },
       ]);
 
-      const interfaces = await _getAllInterfaces('localhost');
+      const interfaces = await getAllInterfaces('localhost', dnsLookupStub);
 
       expect(interfaces).to.have.lengthOf(2);
       expect(interfaces[0].address).to.equal('127.0.0.1');
@@ -537,7 +531,7 @@ describe('RFC8252HTTPServer', function () {
         { address: '192.168.1.15', family: 4 },
       ]);
 
-      const interfaces = await _getAllInterfaces('localhost');
+      const interfaces = await getAllInterfaces('localhost', dnsLookupStub);
 
       expect(interfaces).to.have.lengthOf(2);
       expect(interfaces[0].address).to.equal('127.0.0.1');

--- a/src/rfc-8252-http-server.spec.ts
+++ b/src/rfc-8252-http-server.spec.ts
@@ -9,7 +9,6 @@ import type { SinonSandbox } from 'sinon';
 import sinon from 'sinon';
 import { promisify } from 'util';
 import { randomBytes } from 'crypto';
-import { promises as dns } from 'dns';
 
 // node-fetch@3 is ESM-only...
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports

--- a/src/rfc-8252-http-server.spec.ts
+++ b/src/rfc-8252-http-server.spec.ts
@@ -488,16 +488,15 @@ describe('RFC8252HTTPServer', function () {
   });
 
   context('with dns duplicates', function () {
-    const originalDnsLookup = dns.lookup;
     let dnsLookupStub: sinon.SinonStub;
+    const _getAllInterfaces = RFC8252HTTPServer['_getAllInterfaces'];
 
     this.beforeEach(function () {
-      dnsLookupStub = sinon.stub();
-      dns.lookup = dnsLookupStub;
+      dnsLookupStub = sinon.stub(dns, 'lookup');
     });
 
     this.afterEach(function () {
-      dns.lookup = originalDnsLookup;
+      sinon.restore();
     });
 
     it('only filters exact duplicates', async function () {
@@ -508,9 +507,7 @@ describe('RFC8252HTTPServer', function () {
         { address: '[::1]', family: 6 },
       ]);
 
-      const interfaces = await RFC8252HTTPServer['_getAllInterfaces'].call(
-        'localhost'
-      );
+      const interfaces = await _getAllInterfaces('localhost');
 
       expect(interfaces).to.have.lengthOf(2);
       expect(interfaces[0].address).to.equal('127.0.0.1');
@@ -525,9 +522,7 @@ describe('RFC8252HTTPServer', function () {
         { address: '127.0.0.1', family: 6 },
       ]);
 
-      const interfaces = await RFC8252HTTPServer['_getAllInterfaces'].call(
-        'localhost'
-      );
+      const interfaces = await _getAllInterfaces('localhost');
 
       expect(interfaces).to.have.lengthOf(2);
       expect(interfaces[0].address).to.equal('127.0.0.1');
@@ -542,9 +537,7 @@ describe('RFC8252HTTPServer', function () {
         { address: '192.168.1.15', family: 4 },
       ]);
 
-      const interfaces = await RFC8252HTTPServer['_getAllInterfaces'].call(
-        'localhost'
-      );
+      const interfaces = await _getAllInterfaces('localhost');
 
       expect(interfaces).to.have.lengthOf(2);
       expect(interfaces[0].address).to.equal('127.0.0.1');


### PR DESCRIPTION
This appears to be the cause of the failures we're seeing in mongosh. The logs indicate that we're getting duplicate dns addresses, which causes us to fire up two servers, one of which will inevitably fail due to address being in use. Here's the corresponding log message:

```
2025-02-26T17:22:33.225Z connection controller INFO  OIDC-PLUGIN [
  { __value: 1002000028 },
  'compass-oidc',
  'Resolved hostnames for local server',
  {
    url: 'http://localhost:37197/redirect',
    urlPort: 37197,
    hostname: 'localhost',
    interfaces: [
      { address: '127.0.0.1', family: 4 },
      { address: '127.0.0.1', family: 4 }
    ]
  }
]
```