### PR TITLE
fix: improve node-fetch compatibility in error cases MONGOSH-2443

### DIFF
--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -28,7 +28,11 @@ import { verifySuccessfulAuthCodeFlowLog } from '../test/log-hook-verification-h
 import { automaticRefreshTimeoutMS, MongoDBOIDCPluginImpl } from './plugin';
 import sinon from 'sinon';
 import { publicPluginToInternalPluginMap_DoNotUseOutsideOfTests } from './api';
-import type { Server as HTTPServer } from 'http';
+import type {
+  Server as HTTPServer,
+  ServerResponse,
+  IncomingMessage,
+} from 'http';
 import { createServer as createHTTPServer } from 'http';
 import type { AddressInfo } from 'net';
 import type {
@@ -1239,6 +1243,7 @@ describe('OIDC plugin (local OIDC provider)', function () {
 describe('OIDC plugin (mock OIDC provider)', function () {
   let provider: OIDCMockProvider;
   let getTokenPayload: OIDCMockProviderConfig['getTokenPayload'];
+  let overrideRequestHandler: OIDCMockProviderConfig['overrideRequestHandler'];
   let additionalIssuerMetadata: OIDCMockProviderConfig['additionalIssuerMetadata'];
   let receivedHttpRequests: string[] = [];
   const tokenPayload = {
@@ -1264,8 +1269,13 @@ describe('OIDC plugin (mock OIDC provider)', function () {
       additionalIssuerMetadata() {
         return additionalIssuerMetadata?.() ?? {};
       },
-      overrideRequestHandler(url: string) {
+      overrideRequestHandler(
+        url: string,
+        req: IncomingMessage,
+        res: ServerResponse
+      ) {
         receivedHttpRequests.push(url);
+        return overrideRequestHandler?.(url, req, res);
       },
     });
   });
@@ -1277,6 +1287,7 @@ describe('OIDC plugin (mock OIDC provider)', function () {
   beforeEach(function () {
     receivedHttpRequests = [];
     getTokenPayload = () => tokenPayload;
+    overrideRequestHandler = undefined;
     additionalIssuerMetadata = undefined;
   });
 
@@ -1531,6 +1542,40 @@ describe('OIDC plugin (mock OIDC provider)', function () {
         status: 500,
         statusText: 'Internal Server Error',
       });
+    });
+
+    it('handles JSON failure responses from the IDP', async function () {
+      overrideRequestHandler = (url, req, res) => {
+        if (new URL(url).pathname.endsWith('/token')) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              error: 'jsonfailure',
+              error_description: 'failure text',
+            })
+          );
+        }
+      };
+      const plugin = createMongoDBOIDCPlugin({
+        openBrowserTimeout: 60_000,
+        openBrowser: fetchBrowser,
+        allowedFlows: ['auth-code'],
+        redirectURI: 'http://localhost:0/callback',
+        customFetch: sinon.stub().callsFake(fetch),
+      });
+
+      try {
+        await requestToken(plugin, {
+          issuer: provider.issuer,
+          clientId: 'mockclientid',
+          requestScopes: [],
+        });
+        expect.fail('missed exception');
+      } catch (err: any) {
+        expect(err.message).to.equal(
+          'server responded with an error in the response body: caused by HTTP response 400 : jsonfailure, failure text'
+        );
+      }
     });
   });
 });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -12,6 +12,7 @@ import {
   getRefreshTokenId,
   improveHTTPResponseBasedError,
   messageFromError,
+  nodeFetchCompat,
   normalizeObject,
   throwIfAborted,
   TokenSet,
@@ -405,7 +406,7 @@ export class MongoDBOIDCPluginImpl implements MongoDBOIDCPlugin {
     this.logger.emit('mongodb-oidc-plugin:outbound-http-request', { url });
 
     try {
-      const response = await this.doFetch(url, init);
+      const response = nodeFetchCompat(await this.doFetch(url, init));
       this.logger.emit('mongodb-oidc-plugin:outbound-http-request-completed', {
         url,
         status: response.status,

--- a/src/util.ts
+++ b/src/util.ts
@@ -260,6 +260,10 @@ export async function improveHTTPResponseBasedError<T>(
   const cause = getCause(err);
   if (cause) {
     try {
+      const statusObject =
+        'status' in cause ? cause : (err as Record<string, unknown>);
+      if (!statusObject.status) return err;
+
       let body = '';
       try {
         if ('text' in cause && typeof cause.text === 'function')
@@ -286,8 +290,6 @@ export async function improveHTTPResponseBasedError<T>(
       }
       if (!errorMessageFromBody) errorMessageFromBody = `: ${body}`;
 
-      const statusObject =
-        'status' in cause ? cause : (err as Record<string, unknown>);
       const statusTextInsert =
         'statusText' in statusObject
           ? `(${String(statusObject.statusText)})`


### PR DESCRIPTION
`node-fetch` currently does not return a body that is a web/standard `ReadableStream`, which is what openid-client expects. Since it only makes use of this in error cases, no additional cases are broken, but the error message is highly unhelpful in these cases.

Unfortunately, it is not trivial to resolve this without fully wrapping the `node-fetch`, so this provides a limited compatibility layer rather than a full-featured one. (Note – I'm opening the PR with this approach but I'd be up for changing this if somebody feels strongly that we should put in the effort to provide a full layer around `Response`. We can't "just" replace `.body` only because node-fetch's `.text()` and `.json()` methods expect it to be a Node.js stream.)