### PR TITLE
chore: try disabling GPU for Chrome to fix Windows tests

### DIFF
--- a/test/oidc-test-provider.ts
+++ b/test/oidc-test-provider.ts
@@ -184,7 +184,12 @@ async function spawnBrowser(
   hideLogs?: boolean // For when real credentials are used in a flow
 ): Promise<Browser> {
   const options = {
-    capabilities: { browserName: 'chrome' },
+    capabilities: {
+      browserName: 'chrome',
+      'goog:chromeOptions': {
+        args: ['--disable-gpu-sandbox', '--disable-gpu'],
+      },
+    },
     waitforTimeout: 10_000,
     waitforInterval: 100,
     logLevel: hideLogs ? 'error' : 'info',
@@ -240,6 +245,8 @@ async function spawnBrowser(
               `--app=${url}`,
               '--disable-save-password-bubble',
               '--no-sandbox',
+              '--disable-gpu-sandbox',
+              '--disable-gpu',
             ],
           },
           'wdio:enforceWebDriverClassic': true,

--- a/test/oidc-test-provider.ts
+++ b/test/oidc-test-provider.ts
@@ -189,6 +189,8 @@ async function spawnBrowser(
     '--disable-software-rasterizer',
     '--disable-gpu-compositing',
     '--disable-gpu-rasterization',
+    '--disable-accelerated-video-decode',
+    '--no-sandbox',
   ];
   const options = {
     capabilities: {
@@ -251,7 +253,6 @@ async function spawnBrowser(
             args: [
               `--app=${url}`,
               '--disable-save-password-bubble',
-              '--no-sandbox',
               ...chromeNoGpu,
             ],
           },

--- a/test/oidc-test-provider.ts
+++ b/test/oidc-test-provider.ts
@@ -183,17 +183,24 @@ async function spawnBrowser(
   url: string,
   hideLogs?: boolean // For when real credentials are used in a flow
 ): Promise<Browser> {
+  const chromeNoGpu = [
+    '--disable-gpu-sandbox',
+    '--disable-gpu',
+    '--disable-software-rasterizer',
+    '--disable-gpu-compositing',
+    '--disable-gpu-rasterization',
+  ];
   const options = {
     capabilities: {
       browserName: 'chrome',
       'goog:chromeOptions': {
-        args: ['--disable-gpu-sandbox', '--disable-gpu'],
+        args: chromeNoGpu,
       },
     },
     waitforTimeout: 10_000,
     waitforInterval: 100,
-    logLevel: hideLogs ? 'error' : 'info',
-  } as const;
+    logLevel: hideLogs ? ('error' as const) : ('info' as const),
+  };
 
   // We set ELECTRON_RUN_AS_NODE=1 for tests so that we can use
   // process.execPath to run scripts. Here, we want the actual, regular
@@ -245,8 +252,7 @@ async function spawnBrowser(
               `--app=${url}`,
               '--disable-save-password-bubble',
               '--no-sandbox',
-              '--disable-gpu-sandbox',
-              '--disable-gpu',
+              ...chromeNoGpu,
             ],
           },
           'wdio:enforceWebDriverClassic': true,


### PR DESCRIPTION
Not sure why these started to fail in CI recently, but it's not like our test cases would require GPU acceleration.