### PR TITLE
fix: update spawn to avoid Node.js 24 deprecation warnings

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -589,12 +589,17 @@ export class MongoDBOIDCPluginImpl implements MongoDBOIDCPlugin {
       return await defaultOpener(options);
     }
     if (typeof this.options.openBrowser?.command === 'string') {
-      const child = spawn(this.options.openBrowser.command, [options.url], {
-        shell: true,
-        stdio: 'ignore',
-        detached: true,
-        signal: this.options.openBrowser.abortable ? options.signal : undefined,
-      });
+      const child = spawn(
+        `${this.options.openBrowser.command} ${options.url}`,
+        {
+          shell: true,
+          stdio: 'ignore',
+          detached: true,
+          signal: this.options.openBrowser.abortable
+            ? options.signal
+            : undefined,
+        }
+      );
       child.unref();
       return child;
     }


### PR DESCRIPTION
Using spawn as we used to triggers DEP0190, and this breaks some tests that depend on stdout to be clean in mongosh.