### PR TITLE
chore: adjust publish workflow to allow for trusted publishing

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,6 +3,10 @@ name: Publish Release
 on:
   workflow_dispatch:
 
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
 jobs:
   publish:
     name: Publish Release
@@ -33,8 +37,6 @@ jobs:
 
       - name: Publish
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Read Version
         id: get-version


### PR DESCRIPTION
Based on the [docs](https://docs.npmjs.com/trusted-publishers), this is the only thing we need to do in addition to the wiring on the npmjs.org side