### PR TITLE
chore: make sure npm version is up to date and consistent in gh ci

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,6 +24,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install npm 11
+        run: |
+          npm install -g npm@11
+          npm -v
         # the oidc-provider package we use doesn't list Node.js 20, 22 and 24 as supported
       - name: Install Dependencies
         run: npm ci --ignore-engines
@@ -48,6 +52,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install npm 11
+        run: |
+          npm install -g npm@11
+          npm -v
       - name: Install Dependencies
         run: npm ci --ignore-engines
       - name: Compile
@@ -66,6 +74,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22.x
+
+      - name: Install npm 11
+        run: |
+          npm install -g npm@11
+          npm -v
 
       - name: Install Dependencies
         run: npm ci --ignore-engines

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           node-version: 20.x
 
+      - name: Install npm 11
+        run: |
+          npm install -g npm@11
+          npm -v
+
       - name: Bump version
         run: |
           echo "new-version=$(npm version ${{ github.event.inputs.exact_version || github.event.inputs.version_update_type }} --no-git-tag-version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,6 +29,11 @@ jobs:
           node-version: 22.x
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Install npm 11
+        run: |
+          npm install -g npm@11
+          npm -v
+
       - name: Install Dependencies
         run: npm ci --ignore-engines
 


### PR DESCRIPTION
Didn't notice that we're not enforcing npm version in this repo yet