### PR TITLE
chore: use same token as the merge task

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -68,5 +68,5 @@ jobs:
           name: ${{ steps.get-version.outputs.package_version }}
           commit: main
           tag: v${{ steps.get-version.outputs.package_version }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           draft: false


### PR DESCRIPTION
Not exactly sure how this release publishing worked before, but I think we're using the wrong variable when setting the token here?