### PR TITLE
feat: make  scope optional COMPASS-10811

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -228,6 +228,16 @@ export interface MongoDBOIDCPluginOptions {
    *   per RFC 8414.
    */
   discoveryAlgorithm?: 'oidc' | 'oauth2';
+
+  /**
+   * The default scopes to request
+   *
+   * The default value is `['openid', 'offline_access']`.
+   * This will be reduced if the scopes are not supported by the auth server,
+   * but `scopes_supported` is optional per RFC 9728, so the plugin might not be able
+   * to determine the supported scopes.
+   */
+  defaultScopes?: string[];
 }
 
 /** @public */

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -1366,6 +1366,43 @@ describe('OIDC plugin (mock OIDC provider)', function () {
     });
   });
 
+  context('with options.defaultScopes', function () {
+    async function getScopes(
+      pluginOptions: Partial<MongoDBOIDCPluginOptions>,
+      idpInfo: Partial<IdPServerInfo> = {}
+    ): Promise<string[]> {
+      const plugin = createMongoDBOIDCPlugin({
+        openBrowserTimeout: 60_000,
+        openBrowser: fetchBrowser,
+        allowedFlows: ['auth-code'],
+        redirectURI: 'http://localhost:0/callback',
+        ...pluginOptions,
+      });
+      const result = await requestToken(plugin, {
+        issuer: provider.issuer,
+        clientId: 'mockclientid',
+        requestScopes: [],
+        ...idpInfo,
+      });
+      return String(getJWTContents(result.accessToken).scope).split(' ').sort();
+    }
+
+    it('replaces the built-in defaults when set (opts out of openid)', async function () {
+      expect(
+        await getScopes({ defaultScopes: ['offline_access'] })
+      ).to.deep.equal(['offline_access']);
+    });
+
+    it('unions defaultScopes with server-supplied requestScopes', async function () {
+      expect(
+        await getScopes(
+          { defaultScopes: ['offline_access'] },
+          { requestScopes: ['servergroup'] }
+        )
+      ).to.deep.equal(['offline_access', 'servergroup']);
+    });
+  });
+
   context('when drivers re-request tokens early', function () {
     let plugin: MongoDBOIDCPlugin;
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -473,7 +473,8 @@ export class MongoDBOIDCPluginImpl implements MongoDBOIDCPlugin {
     const makeScope = (idpMetadata: AuthorizationServerMetadata) =>
       [
         ...new Set([
-          ...this.getSupportedDefaultScopes(idpMetadata),
+          ...(this.options.defaultScopes ??
+            this.getSupportedDefaultScopes(idpMetadata)),
           ...(serverMetadata.requestScopes ?? []),
         ]),
       ].join(' ');


### PR DESCRIPTION
Previous behaviour:
 
The package uses `getSupportedDefaultScopes` which checks what the server supports. But, if the server doesn't advertise the scopes it supports (which is recommended but not required for oauth2 servers per RFC 9728), it defaults to ['openid', 'offline_access'].
Requesting `openid` is a reasonable default for `oidc-plugin`, but for our usecase we need to override it as we're dealing with an oauth2 server that rejects such request with an `invalid_scope`