### PR TITLE
chore: add codeql workflow_dispatch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,12 @@ on:
     branches: ['main']
   schedule:
     - cron: '30 14 * * 4'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref or full commit SHA to scan
+        required: false
+        type: string
 
 jobs:
   analyze:
@@ -42,6 +48,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+          fetch-depth: 0
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL


### PR DESCRIPTION
Turns out codeql was disabled when the last version was generated (because of long inactivity), adding this so I can re-run manually for the corresponding commit